### PR TITLE
This will allow much better support for gfx1032 and other things not …

### DIFF
--- a/comfy/flash_attn_triton_amd/utils.py
+++ b/comfy/flash_attn_triton_amd/utils.py
@@ -269,12 +269,8 @@ def get_input_shapes():
 def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 
-
 def is_cdna():
-    return is_hip() and triton.runtime.driver.active.get_current_target().arch in ('gfx940', 'gfx941', 'gfx942',
-                                                                                   'gfx90a', 'gfx908')
-
+    return is_hip() and triton.runtime.driver.active.get_current_target().arch.startswith('gfx9')
 
 def is_rdna():
-    return is_hip() and triton.runtime.driver.active.get_current_target().arch in ("gfx1030", "gfx1031", "gfx1035", "gfx1100", "gfx1101",
-                                                                                   "gfx1102", "gfx1103", "gfx1150", "gfx1200", "gfx1201")
+    return is_hip() and triton.runtime.driver.active.get_current_target().arch.startswith("gfx1")


### PR DESCRIPTION
…specifically named

```
def is_rdna():
    return is_hip() and triton.runtime.driver.active.get_current_target().arch in ("gfx1030", "gfx1100", "gfx1101",
                                                                                   "gfx1102", "gfx1200", "gfx1201")
```

Is just lame when you can do:

```
def is_rdna():
    return is_hip() and triton.runtime.driver.active.get_current_target().arch.startswith("gfx1")
```