### PR TITLE
Have to install pytorch 2.8

### DIFF
--- a/install-n.bat
+++ b/install-n.bat
@@ -59,6 +59,7 @@ if "%PY_MINOR%"=="12" (
 :: patching triton
 pip install --force-reinstall pypatch-url --quiet
 pypatch-url apply https://raw.githubusercontent.com/sfinktah/amd-torch/refs/heads/main/patches/triton-3.4.0+gita9c80202-cp311-cp311-win_amd64.patch -p 4 triton
+pypatch-url apply https://raw.githubusercontent.com/sfinktah/amd-torch/refs/heads/main/patches/torch-2.7.0+cu118-cp311-cp311-win_amd64.patch -p 4 torch
 
 echo  ::  %time:~0,8%  ::  - Installing flash-attention
 

--- a/install-n.bat
+++ b/install-n.bat
@@ -27,10 +27,9 @@ echo.
 echo  ::  %time:~0,8%  ::  Beginning installation ...
 echo.
 echo  ::  %time:~0,8%  ::  - Installing required packages
+pip install --force-reinstall --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118 --quiet
 pip install -r requirements.txt --quiet
 echo  ::  %time:~0,8%  ::  - Installing torch for AMD GPUs (First file is 2.7 GB, please be patient)
-pip uninstall torch torchvision torchaudio -y --quiet
-pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/cu118 --quiet
 echo  ::  %time:~0,8%  ::  - Installing onnxruntime (required by some nodes)
 pip install onnxruntime --quiet
 echo  ::  %time:~0,8%  ::  - (temporary numpy fix)


### PR DESCRIPTION
So it turns out that my patches (which you didn't add, anyway) don't work with the cuda version of pytorch 2.7.

So it's pytorch 2.8 or no working triton.

I thought I had tested them on the original zluda+n build, but I must have gone straight to pytorch 2.8.

Here are the required changes, or you can rollback.  Though triton still wouldn't really work, it seems to very angrily not work with pytorch 2.7, refusing to run jobs.