### PR TITLE
Deleted torch.backends.cudnn.benchmark line, defaults are fine

### DIFF
--- a/comfy/customzluda/zluda.py
+++ b/comfy/customzluda/zluda.py
@@ -437,8 +437,7 @@ try:
         print("  ::  Enabled cuDNN")
     else:
         print("  ::  Disabled cuDNN")
-    torch.backends.cudnn.benchmark = False
-    
+
     @triton.jit
     def _zluda_kernel_test(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
         pid = tl.program_id(axis=0)


### PR DESCRIPTION
I found out what torch.backends.cudnn.benchmark did after I wrote the last PR.  

tl;dr it default to False when cudnn is disable, and True when it is enabled, which is exactly where you want it.  It's just the dynamic compiler that tries lots of things. 

You had the right idea thinking to turn it off to speed up non-CUDNN stuff, but Torch had already thought of that and so it is automatically disabled :)