### PR TITLE
zluda.py "Expanded gfx identifier, lowercase gpu search, detect Triton version"

### DIFF
--- a/comfy/customzluda/zluda.py
+++ b/comfy/customzluda/zluda.py
@@ -507,6 +507,7 @@ except Exception as e:
 
 # # ------------------- ZLUDA Core Implementation -------------------
 MEM_BUS_WIDTH = {
+    k.lower(): v for k, v in {
     "AMD Radeon RX 9070 XT": 256,
     "AMD Radeon RX 9070": 256,
     "AMD Radeon RX 9070 GRE": 192,
@@ -559,7 +560,8 @@ MEM_BUS_WIDTH = {
     "AMD Radeon PRO W6400": 64,
     "AMD Radeon Pro W5700": 256,
     "AMD Radeon Pro W5500": 128,
-    "AMD Radeon Pro VII": 4096, 
+    "AMD Radeon Pro VII": 4096,
+    }.items()
 }
 
 # ------------------- Device Properties Implementation -------------------
@@ -659,8 +661,8 @@ def do_hijack():
             def patched_props(device):
                 props = _get_props(device)
                 name = torch.cuda.get_device_name()[:-8]  # Remove [ZLUDA]
-                props["mem_bus_width"] = MEM_BUS_WIDTH.get(name, 128)
-                if name not in MEM_BUS_WIDTH:
+                props["mem_bus_width"] = MEM_BUS_WIDTH.get(name.lower(), 128)
+                if name.lower() not in MEM_BUS_WIDTH:
                     print(f'  ::  Using default mem_bus_width=128 for {name}')
                 return props
             triton.runtime.driver.active.utils.get_device_properties = patched_props


### PR DESCRIPTION
Initial idea was to add RDNA3.5 so users don't have to manually set `TRITON_OVERRIDE_ARCH` for 8000S Series. 
But, I added more than initially planed.

**[updated: September  9, 2025]**

In summary:

- added simple Triton version check, could be helpful for troubleshooting reports. 
_Unsure if it's right place to put it, but after testing cuDNN toggled just fine._
- set lookup inside `mem_bus_width` in lower case
_Just in case of incorrect casing on Radeon Pro (PRO) GPUs._
- added Vega cards to `mem_bus_width`. 
_No clue if it has effect or just placebo, can't test._
- expanded `gpu_name_to_gfx` with all missing cards and **correct** gfx
added RDNA4 and RDNA3.5 
added missing Polaris cards to prevent fallback to gfx1010 and gfx1030 with 'rx 5/rx 6'
- changed `gpu_name_to_gfx` function to set of rules
sorted to prevent incorrect detection, for example RX 6800s as RX 6800

~~Might need some re-adjustments, 
for example in RDNA2 'rx 6800' **gfx1030 return** is above 'rx 6800m' (gfx1031) and 'rx 6800s' (gfx1032).~~

<details><summary>print Triton version example</summary>
<p>

<img width="600" height="497" alt="tritonversion" src="https://github.com/user-attachments/assets/487813db-fa01-412a-ad57-d205b0a36a89" />


</p>
</details> 