### PR TITLE
move CFZ nodes into CFZ category

### DIFF
--- a/cfz/nodes/CFZ-caching/cfz_caching_condition.py
+++ b/cfz/nodes/CFZ-caching/cfz_caching_condition.py
@@ -45,7 +45,7 @@ class save_conditioning:
     RETURN_TYPES = ("CONDITIONING",)
     RETURN_NAMES = ("conditioning",)
     FUNCTION     = "save_conditioning"
-    CATEGORY     = "CFZ Save-Load Conditioning"
+    CATEGORY     = "CFZ/conditioning"
 
     def save_conditioning(self, conditioning, cache_name):
         """Save conditioning to cache with custom name"""
@@ -126,7 +126,7 @@ class load_conditioning:
     RETURN_TYPES = ("CONDITIONING",)
     RETURN_NAMES = ("conditioning",)
     FUNCTION     = "load_conditioning"
-    CATEGORY     = "CFZ Save-Load Conditioning"
+    CATEGORY     = "CFZ/conditioning"
 
     @classmethod
     def get_cached_files(cls):
@@ -226,7 +226,7 @@ class CFZ_PrintMarker:
     RETURN_NAMES = ("output",)
     OUTPUT_NODE = True
     FUNCTION = "run"
-    CATEGORY = "CFZ Utils/Debug"
+    CATEGORY = "CFZ/utils/debug"
 
     def run(self, message, timer_name="workflow_timer", is_start_point=False, is_end_point=False, 
             show_current_time=True, trigger=None, unique_id=None, extra_pnginfo=None):

--- a/cfz/nodes/cfz_cudnn.toggle.py
+++ b/cfz/nodes/cfz_cudnn.toggle.py
@@ -30,7 +30,7 @@ class CUDNNToggleAutoPassthrough:
     RETURN_TYPES = ("MODEL", "CONDITIONING", "LATENT", "AUDIO", "IMAGE", "WANVIDEOMODEL", anyType, "BOOLEAN", "BOOLEAN")
     RETURN_NAMES = ("model", "conditioning", "latent", "audio", "image", "wan_model", "any_output", "prev_cudnn", "prev_benchmark")
     FUNCTION = "toggle"
-    CATEGORY = "utils"
+    CATEGORY = "CFZ/utils"
 
     def toggle(self, enable_cudnn, cudnn_benchmark, any_input=None, wan_model=None, model=None, conditioning=None, latent=None, audio=None, image=None):
         prev_cudnn = torch.backends.cudnn.enabled

--- a/cfz/nodes/cfz_patcher.py
+++ b/cfz/nodes/cfz_patcher.py
@@ -247,7 +247,7 @@ class CheckpointLoaderQuantized2:
 
     RETURN_TYPES = ("MODEL", "CLIP", "VAE")
     FUNCTION = "load_quantized"
-    CATEGORY = "Loaders (Quantized)"
+    CATEGORY = "CFZ/loaders"
     OUTPUT_NODE = False
 
     def load_quantized(self, ckpt_name, enable_quant, use_asymmetric, quant_dtype, 
@@ -302,7 +302,7 @@ class ModelQuantizationPatcher:
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch_model"
-    CATEGORY = "Model Patching"
+    CATEGORY = "CFZ/model patches"
     OUTPUT_NODE = False
 
     def patch_model(self, model, use_asymmetric, quant_dtype, use_int8_matmul):
@@ -347,7 +347,7 @@ class UNetQuantizationPatcher:
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch_unet"
-    CATEGORY = "Model Patching"
+    CATEGORY = "CFZ/model patches"
     OUTPUT_NODE = False
 
     def get_model_memory_usage(self, model, force_calculation=False):

--- a/cfz/nodes/cfz_vae_loader.py
+++ b/cfz/nodes/cfz_vae_loader.py
@@ -15,7 +15,7 @@ class CFZVAELoader:
     
     RETURN_TYPES = ("VAE",)
     FUNCTION = "load_vae"
-    CATEGORY = "loaders"
+    CATEGORY = "CFZ/loaders"
     TITLE = "CFZ VAE Loader"
 
     def load_vae(self, vae_name, precision):


### PR DESCRIPTION
Moved all CFZ nodes into corresponding categories, for simplicity. 

- CFZ/conditioning:
CFZ Save Conditioning, CFZ Load Conditioning
- CFZ/model patches:
CFZ Model Quantization Patcher, CFZ UNet Quantization Patcher
- CFZ/loaders:
CFZ Checkpoint Loader (Optimized), CFZ VAE Loader
- CFZ/utils: 
CFZ CUDNN Toggle
- CFZ/utils/debug:
CFZ Print Marker

Didn't touch node names, that could break existing workflows.