### PR TITLE
cache-clean.bat fix pause

### DIFF
--- a/cache-clean.bat
+++ b/cache-clean.bat
@@ -44,9 +44,9 @@ if defined COMFYUI_DIR (
 
 echo.
 echo.
-echo Press Y to continue or any other key to cancel...
-for /f %%k in ('powershell -nologo -command "[console]::ReadKey($true).KeyChar"') do set "key=%%k"
-if /i not "%key%"=="Y" exit /b
+echo Press 1 to continue or 2 to cancel...
+choice /c 12 /n /m "Enter your choice:"
+if errorlevel 2 exit /b
 
 echo.
 echo ============================================
@@ -159,4 +159,10 @@ echo - Close any running applications that might be using these directories
 echo - Run this script as Administrator
 echo - Manually delete the directories that couldn't be removed
 echo.
-pause
+:: Pause only if script was double-clicked (non-interactive mode)
+echo %cmdcmdline% | findstr /i "\/c" >nul
+if %errorlevel%==0 (
+    pause
+) else (
+    pause
+)


### PR DESCRIPTION
~~- replaced first pause with power shell confirmation  (Y to continue or any key to cancel)~~
 - **UPDATE:** replaced first pause with 1 or 2 confirmation (for non-English keyboards)
 - **UPDATE**: added double pause at the end, in hope to catch any potential skips once cleaning is done

Reason: pressing "any key to continue" other than ENTER or SPACE (e.g. arrows/fn keys) causes batch to skip final pause and close if launched with double-click. Leaving user with no info.
This is batch issue when executed through explorer and not via cmd or inside other batch file.