### PR TITLE
fix breaking git pull and incorrect MSVC check

### DIFF
--- a/comfyui.bat
+++ b/comfyui.bat
@@ -88,10 +88,10 @@ for /f "delims=" %%R in ('git rev-parse @{u}') do set REMOTE=%%R
 if NOT "%LOCAL%"=="%REMOTE%" (
     echo.
     echo [INFO] Update available. New commits:
-    git log --oneline %LOCAL%..%REMOTE%
+    git --no-pager log --oneline %LOCAL%..%REMOTE%
     echo.
     echo [INFO] Pulling updates...
-    git pull
+    git --no-pager pull
 ) else (
     echo [INFO] Already up to date.
 )


### PR DESCRIPTION
No pager on git log and pull to prevent breaking when output is long. #324


- removed MSVC check, if was fragile and misleading with false positives if not in PATH, also not required for Triton
- reworked build tools check for version and components (still via vswhere, no more split suffix/prefix guess works for msvc)
- prints only build tools version (same as before)
- extra print only if any of mandatory components (for triton compiling) are not installed
- expanded error message if unable to detect build tools:
`[ERROR] Visual Studio Build Tools not found.`
`         Please install from https://aka.ms/vs/17/release/vs_BuildTools.exe`
`         Make sure to select "Desktop development with C++" with optional components:`
`         CMake tools for Windows, Clang compiler for Windows, MSVC x64/x86 build tools, and Windows 10/11 SDK.`