### PR TITLE
fix: check for version compatibility before calling PyTorch method

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -25,7 +25,7 @@ import comfy.rmsnorm
 import contextlib
 
 def run_every_op():
-    if torch.compiler.is_compiling():
+    if comfy.model_management.torch_version_numeric >= (2, 3) and torch.compiler.is_compiling():
         return
 
     comfy.model_management.throw_exception_if_processing_interrupted()


### PR DESCRIPTION
This worked for my environment using a Radeon RX Vega 56 (gpx900 architecture).