### PR TITLE
Fix rare DLL load failure for nvcuda.dll in Python

### DIFF
--- a/comfy/customzluda/nvcuda.zluda_get_nightly_flag.py
+++ b/comfy/customzluda/nvcuda.zluda_get_nightly_flag.py
@@ -3,11 +3,18 @@ import os
 import sys
 
 def main():
-    dll_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'zluda', 'nvcuda.dll'))
+    zluda_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', 'zluda')
+    )
+
+    dll_path = os.path.join(zluda_dir, 'nvcuda.dll')
 
     if not os.path.isfile(dll_path):
         print(f"ERROR: DLL not found: {dll_path}")
         sys.exit(1)
+
+    if hasattr(os, "add_dll_directory"):
+        os.add_dll_directory(zluda_dir)
 
     try:
         zluda_dll = ctypes.CDLL(dll_path)


### PR DESCRIPTION
Registers the ZLUDA directory as a DLL search path to fix a rare case where Python fails to load nvcuda.dll or its dependencies on Windows.

Error:
"Could not load DLL: Could not find module 'dll_path' (or one of its dependencies). Try using the full path with constructor syntax."