### PR TITLE
Automatically disabling and enabling CUDA on a problematic node

### DIFF
--- a/custom_nodes/00_zluda_vae_fix.py
+++ b/custom_nodes/00_zluda_vae_fix.py
@@ -1,0 +1,84 @@
+import torch
+import torch.nn.functional as F
+import comfy.sd
+import contextlib
+
+# Контекст для временного отключения cuDNN
+@contextlib.contextmanager
+def disable_cudnn():
+    """Временно отключает cuDNN"""
+    prev_enabled = torch.backends.cudnn.enabled
+    prev_benchmark = torch.backends.cudnn.benchmark
+    
+    torch.backends.cudnn.enabled = False
+    torch.backends.cudnn.benchmark = False
+    
+    try:
+        yield
+    finally:
+        torch.backends.cudnn.enabled = prev_enabled
+        torch.backends.cudnn.benchmark = prev_benchmark
+
+# Патчим VAE encode
+_original_vae_encode = comfy.sd.VAE.encode
+
+def patched_vae_encode(self, pixel_samples):
+    """VAE encode всегда без cuDNN"""
+    print("[ZLUDA VAE] Encoding с отключённым cuDNN...")
+    
+    with disable_cudnn():
+        try:
+            result = _original_vae_encode(self, pixel_samples)
+            print("[ZLUDA VAE] Encode успешно завершён")
+            return result
+        except RuntimeError as e:
+            if "FIND was unable" in str(e):
+                print("[ZLUDA VAE] GPU ошибка, используем CPU...")
+                # Fallback на CPU
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                
+                original_device = next(self.first_stage_model.parameters()).device
+                self.first_stage_model.to('cpu')
+                pixel_samples_cpu = pixel_samples.to('cpu')
+                
+                result = _original_vae_encode(self, pixel_samples_cpu)
+                
+                self.first_stage_model.to(original_device)
+                return result.to(original_device)
+            raise
+
+comfy.sd.VAE.encode = patched_vae_encode
+
+# Также патчим decode на всякий случай
+_original_vae_decode = comfy.sd.VAE.decode
+
+def patched_vae_decode(self, samples):
+    """VAE decode с отключённым cuDNN"""
+    with disable_cudnn():
+        try:
+            return _original_vae_decode(self, samples)
+        except RuntimeError as e:
+            if "FIND was unable" in str(e):
+                print("[ZLUDA VAE] Decode fallback на CPU...")
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                
+                original_device = next(self.first_stage_model.parameters()).device
+                self.first_stage_model.to('cpu')
+                samples_cpu = samples.to('cpu')
+                
+                result = _original_vae_decode(self, samples_cpu)
+                
+                self.first_stage_model.to(original_device)
+                return result.to(original_device)
+            raise
+
+comfy.sd.VAE.decode = patched_vae_decode
+
+print("=" * 50)
+print("[ZLUDA] VAE авто-патч активирован")
+print("[ZLUDA] VAE encode/decode = без cuDNN")
+print("[ZLUDA] Остальное = с cuDNN")
+print("=" * 50)
+NODE_CLASS_MAPPINGS = {}

--- a/custom_nodes/GetOutputDirectory.py
+++ b/custom_nodes/GetOutputDirectory.py
@@ -1,0 +1,18 @@
+import torch
+import os
+import folder_paths 
+
+class GetOutputDirectory:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {},
+                "optional": {},
+        }
+    RETURN_TYPES = ("STRING",) 
+    FUNCTION = "get_output_path"
+    def get_output_path(self):
+        output_dir = folder_paths.get_output_directory()
+        return (output_dir,)
+
+NODE_CLASS_MAPPINGS = {"GetOutputDirectory": GetOutputDirectory}
+NODE_DISPLAY_NAME_MAPPINGS = {"GetOutputDirectory_Custom": "Get Output Directory Path"}


### PR DESCRIPTION
Automatically disabling and enabling CUDA on a problematic node Errors related to engine loss on the AMD Radeon RX 6700 XT graphics card have been resolved after KSampler was deprecated. A further improvement is the ability to specify nodes on which to disable CUDA in the comfyui-n.bat launch settings.